### PR TITLE
docs: mention `cargo_extra_args` for `rust-mlua` build backend

### DIFF
--- a/docs/guides/lux-toml.md
+++ b/docs/guides/lux-toml.md
@@ -335,7 +335,7 @@ type = "rust-mlua"
 target_path = "target"
 default_features = false # Passes --no-default-features to Cargo.
 features = [] # Lux will automatically pass the correct mlua feature based on the Lua version.
-
+cargo_extra_args = [] # extra arguments to pass to `cargo build`
 
 [build.modules] # (optional)
 # This expects that Cargo will build a native library in `<target>/release/libalt_name.so`.


### PR DESCRIPTION
This PR adds information about the `cargo_extra_args` setting for the `rust-mlua` build backend.