### PR TITLE
docs: add more detail about setting `source.dir` for workspace members

### DIFF
--- a/docs/guides/multi-project-workspaces.md
+++ b/docs/guides/multi-project-workspaces.md
@@ -41,4 +41,7 @@ version = "1.0.0"
 - You should still declare a version so that the package can be published.
 - If your project lives in a subdirectory, you should also set `source.dir`.
   Make sure it points to the correct directory in any archives specified by `source.url`.
+  For example, if the archive extracts to a folder named `my_project`,
+  and the project is located within the subdirectory `foo/bar`, 
+  set `source.dir = my_project/foo/bar`.
 :::


### PR DESCRIPTION
This PR adds an example on how to set the `source.dir` setting for workspace members. 

I was at first confused about how to set `source.dir` appropriately and had to go back to the `rockspec` documentation to reason about it. This clarifies that `source.dir` should include, in addition to any subdirectories, the folder name of the extracted archive.